### PR TITLE
fix: errors in word contractions.

### DIFF
--- a/quotes.json
+++ b/quotes.json
@@ -1487,7 +1487,7 @@
     "author": "Chelsea Leyland",
     "source": "https://www.brainyquote.com/quotes/chelsea_leyland_624473",
     "tags": "Beauty, Sleep, Secret",
-    "text": "Sleep is the real beauty secret, but I dont get enough of that."
+    "text": "Sleep is the real beauty secret, but I don't get enough of that."
   },
   {
     "author": "Cheng Yen",
@@ -1579,11 +1579,11 @@
   },
   {
     "author": "Colette",
-    "text": "I love my past. I love my present. I'm not ashamed of what Ive had, and I'm not sad because I have it no longer."
+    "text": "I love my past. I love my present. I'm not ashamed of what I've had, and I'm not sad because I have it no longer."
   },
   {
     "author": "Colette",
-    "text": "I love my past. I love my present. Im not ashamed of what Ive had, and Im not sad because I have it no longer."
+    "text": "I love my past. I love my present. I'm not ashamed of what I've had, and I'm not sad because I have it no longer."
   },
   {
     "author": "Colin Powell",
@@ -1827,7 +1827,7 @@
   },
   {
     "author": "Dalai Lama",
-    "text": "People take different roads seeking fulfilment and happiness. Just because theyre not on your road doesn't mean they've gotten lost."
+    "text": "People take different roads seeking fulfilment and happiness. Just because they're not on your road doesn't mean they've gotten lost."
   },
   {
     "author": "Dalai Lama",
@@ -1891,7 +1891,7 @@
   },
   {
     "author": "Dale Carnegie",
-    "text": "When fate hands us a lemon, lets try to make lemonade."
+    "text": "When fate hands us a lemon, let's try to make lemonade."
   },
   {
     "author": "Dale Carnegie",
@@ -2068,7 +2068,7 @@
   },
   {
     "author": "Dorothy Thompson",
-    "text": "Fear grows in darkness; if you think theres a bogeyman around, turn on the light."
+    "text": "Fear grows in darkness; if you think there's a bogeyman around, turn on the light."
   },
   {
     "author": "Dorothy Thompson",
@@ -2154,7 +2154,7 @@
   },
   {
     "author": "Edith Wharton",
-    "text": "If only wed stop trying to be happy wed have a pretty good time."
+    "text": "If only we'd stop trying to be happy we'd have a pretty good time."
   },
   {
     "author": "Edmond Rostand",
@@ -3380,7 +3380,7 @@
   },
   {
     "author": "John Lennon",
-    "text": "You may say Im a dreamer, but Im not the only one, I hope someday you will join us, and the world will live as one."
+    "text": "You may say I'm a dreamer, but I'm not the only one, I hope someday you will join us, and the world will live as one."
   },
   {
     "author": "John Locke",
@@ -3909,7 +3909,7 @@
   },
   {
     "author": "Louisa Alcott",
-    "text": "I'm not afraid of storms, for Im learning how to sail my ship."
+    "text": "I'm not afraid of storms, for I'm learning how to sail my ship."
   },
   {
     "author": "Louise Hay",
@@ -5253,7 +5253,7 @@
   },
   {
     "author": "Richard Bach",
-    "text": "Argue for your limitations, and sure enough theyre yours."
+    "text": "Argue for your limitations, and sure enough they're yours."
   },
   {
     "author": "Richard Bach",
@@ -5423,7 +5423,7 @@
   },
   {
     "author": "Robert Frost",
-    "text": "In three words I can sum up everything Ive learned about life: it goes on."
+    "text": "In three words I can sum up everything I've learned about life: it goes on."
   },
   {
     "author": "Robert Fulghum",
@@ -6253,7 +6253,7 @@
   },
   {
     "author": "Walter Cronkite",
-    "text": "I can't imagine a person becoming a success who doesn't give this game of life everything hes got."
+    "text": "I can't imagine a person becoming a success who doesn't give this game of life everything he's got."
   },
   {
     "author": "Walter Linn",
@@ -6271,7 +6271,7 @@
     "author": "Walter Reisch",
     "source": "https://www.pinterest.com/pin/69805862960101466",
     "tags": "Calmness, Sleep, Plan",
-    "text": "Tired minds dont plan well. Sleep first, plan later."
+    "text": "Tired minds don't plan well. Sleep first, plan later."
   },
   {
     "author": "Washington Irving",
@@ -6347,7 +6347,7 @@
   },
   {
     "author": "Wayne Dyer",
-    "text": "There is no scarcity of opportunity to make a living at what you love; theres only scarcity of resolve to make it happen."
+    "text": "There is no scarcity of opportunity to make a living at what you love; there's only scarcity of resolve to make it happen."
   },
   {
     "author": "Wayne Dyer",


### PR DESCRIPTION
Searched for and fixed word contractions out of the following list:

```
aren't
there's
can't
they'd
couldn't
they'll
didn't
they're
doesn't
they've
don't
we'd
hadn't
we're
hasn't
we've
haven't
weren't
he'd
what'll
he'll
what're
he's
what's
i'd
what've
i'll
where's
i'm
who'd
i've
who'll
isn't
who're
let's
who's
mightn't
who've
mustn't
won't
shan't
wouldn't
she'd
you'd
she'll
you'll
she's
you're
shouldn't
you've
that's
```